### PR TITLE
Add simple browser-based IDE setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+package-lock.json

--- a/README.md
+++ b/README.md
@@ -1,2 +1,23 @@
-# IDE-Codex-version
-TEsting to create an IDE via Codex
+# IDE Codex Version
+
+This project configures a browser-based IDE using [code-server](https://github.com/coder/code-server).
+
+## Features
+
+- All standard VS Code features in the browser
+- Install any VS Code extension from the marketplace
+- Optional collaboration via Live Share extension
+- Built-in Git integration for GitHub repositories
+- Runs on any machine accessible via a web browser
+
+## Quick Start
+
+```bash
+# Install dependencies
+npm install
+
+# Launch the IDE on http://localhost:3000/
+npm start
+```
+
+After starting, open the provided URL in your browser. Install language packs and extensions as desired. To collaborate, install the "Live Share" extension and share the session URL with others.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "ide-codex-version",
+  "version": "1.0.0",
+  "description": "TEsting to create an IDE via Codex",
+  "main": "index.js",
+  "scripts": {
+    "start": "node server.js",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "dependencies": {
+    "code-server": "^4.100.3"
+  }
+}

--- a/server.js
+++ b/server.js
@@ -1,0 +1,8 @@
+const { spawn } = require('child_process');
+
+const args = ['--host', '0.0.0.0', '--port', process.env.PORT || '3000', '--auth', 'none'];
+
+const child = spawn('code-server', args, { stdio: 'inherit' });
+child.on('exit', code => {
+  process.exit(code);
+});


### PR DESCRIPTION
## Summary
- add documentation for using `code-server`
- set up Node project with `code-server` dependency
- create `server.js` to start the IDE
- ignore `node_modules`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6840a05cba54832cadd7624c04fd4805